### PR TITLE
Default to system Markdown editor if it exists

### DIFF
--- a/Markoff/Info.plist
+++ b/Markoff/Info.plist
@@ -43,7 +43,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>53</string>
+	<string>54</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Previously the app defaulted to the last editor in the list on first launch.
This change will make it default to the application that the user has
previously chosen for opening Markdown files system-wide.