### PR TITLE
Prevent Error Message when Printing

### DIFF
--- a/Markoff/Info.plist
+++ b/Markoff/Info.plist
@@ -25,6 +25,24 @@
 			<key>NSDocumentClass</key>
 			<string>$(PRODUCT_MODULE_NAME).MarkdownDocument</string>
 		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>*</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string></string>
+			<key>CFBundleTypeName</key>
+			<string>Anything</string>
+			<key>CFBundleTypeOSTypes</key>
+			<array>
+				<string>****</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).MarkdownDocument</string>
+		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>

--- a/Markoff/Markoff.entitlements
+++ b/Markoff/Markoff.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.print</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
(Per request by #8, however I don't recommend merging this just yet, as printing is fundamentally broken right now):

This enables the printing entitlement when users attempt to print.
Note: it appears that printing is broken; in the print dialog choosing
"Open PDF in Preview" only yields a blank two-page document using
Markoff/README.md as a test. The "Save as PDF" and "Save as Postscript"
commands have no effect either.